### PR TITLE
fixed version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.4.0",
         "symfony/symfony": "~2.2",
         "solarium/solarium": "3.1.*",
-        "pk/command-extra-bundle": ">=1.0.3"
+        "pk/command-extra-bundle": "~1.0,>=1.0.3"
     },
     "autoload": {
         "psr-0": { "FM": "src/" }


### PR DESCRIPTION
Forceert versie 1.0.3 en hoger van PK's command-extra-bundle

T.a.v van PR https://github.com/treehouselabs/FMSearchBundle/pull/6 en issue https://github.com/treehouselabs/FMSearchBundle/issues/8
