### PR TITLE
Fixed issue with template instance

### DIFF
--- a/src/FM/SearchBundle/Translation/SearchTranslator.php
+++ b/src/FM/SearchBundle/Translation/SearchTranslator.php
@@ -196,7 +196,7 @@ class SearchTranslator
     {
         $placeholders = $this->getPlaceholders($values);
 
-        if ($text instanceof \Twig_Template) {
+        if ($text instanceof \Twig_TemplateWrapper) {
             return $text->render($placeholders);
         } else {
             return $this->twig->render($text, $placeholders);


### PR DESCRIPTION
Translator assumed `twig->load` returns a `Twig_Template` instance, but this has changed to `Twig_TemplateWrapper` instances: https://github.com/twigphp/Twig/blob/master/lib/Twig/Environment.php#L379-L391